### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -29,8 +29,8 @@ def hash_password(password):
     )
     return f"pbkdf2_sha256${PBKDF2_ITERATIONS}${salt.hex()}${derived_key.hex()}"
 
-def verify_password(username: str, password: str, stored_password_hash: str) -> bool:
-    """Verify password against stored hash (PBKDF2 format, with legacy SHA-256 migration)."""
+def verify_password(password: str, stored_password_hash: str) -> bool:
+    """Verify password against stored hash (PBKDF2 format only)."""
     if stored_password_hash.startswith("pbkdf2_sha256$"):
         try:
             _, iterations, salt_hex, expected_hex = stored_password_hash.split("$", 3)
@@ -44,13 +44,6 @@ def verify_password(username: str, password: str, stored_password_hash: str) -> 
         except (ValueError, TypeError):
             return False
 
-    # Backward compatibility for legacy unsalted SHA-256 hashes already stored.
-    # If a legacy hash matches, migrate it to PBKDF2 immediately.
-    legacy_hash = hashlib.sha256(password.encode("utf-8")).hexdigest()
-    if hmac.compare_digest(legacy_hash, stored_password_hash):
-        new_hash = hash_password(password)
-        teachers_collection.update_one({"_id": username}, {"$set": {"password": new_hash}})
-        return True
     return False
 
 @router.post("/login")
@@ -59,7 +52,7 @@ def login(username: str, password: str) -> Dict[str, Any]:
     # Find the teacher in the database
     teacher = teachers_collection.find_one({"_id": username})
     
-    if not teacher or not verify_password(username, password, teacher["password"]):
+    if not teacher or not verify_password(password, teacher["password"]):
         raise HTTPException(status_code=401, detail="Invalid username or password")
     
     # Return teacher information (excluding password)

--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -29,8 +29,8 @@ def hash_password(password):
     )
     return f"pbkdf2_sha256${PBKDF2_ITERATIONS}${salt.hex()}${derived_key.hex()}"
 
-def verify_password(password: str, stored_password_hash: str) -> bool:
-    """Verify password against stored hash (PBKDF2 format, with legacy SHA-256 fallback)."""
+def verify_password(username: str, password: str, stored_password_hash: str) -> bool:
+    """Verify password against stored hash (PBKDF2 format, with legacy SHA-256 migration)."""
     if stored_password_hash.startswith("pbkdf2_sha256$"):
         try:
             _, iterations, salt_hex, expected_hex = stored_password_hash.split("$", 3)
@@ -45,8 +45,13 @@ def verify_password(password: str, stored_password_hash: str) -> bool:
             return False
 
     # Backward compatibility for legacy unsalted SHA-256 hashes already stored.
+    # If a legacy hash matches, migrate it to PBKDF2 immediately.
     legacy_hash = hashlib.sha256(password.encode("utf-8")).hexdigest()
-    return hmac.compare_digest(legacy_hash, stored_password_hash)
+    if hmac.compare_digest(legacy_hash, stored_password_hash):
+        new_hash = hash_password(password)
+        teachers_collection.update_one({"_id": username}, {"$set": {"password": new_hash}})
+        return True
+    return False
 
 @router.post("/login")
 def login(username: str, password: str) -> Dict[str, Any]:
@@ -54,7 +59,7 @@ def login(username: str, password: str) -> Dict[str, Any]:
     # Find the teacher in the database
     teacher = teachers_collection.find_one({"_id": username})
     
-    if not teacher or not verify_password(password, teacher["password"]):
+    if not teacher or not verify_password(username, password, teacher["password"]):
         raise HTTPException(status_code=401, detail="Invalid username or password")
     
     # Return teacher information (excluding password)

--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -5,6 +5,8 @@ Authentication endpoints for the High School Management System API
 from fastapi import APIRouter, HTTPException
 from typing import Dict, Any
 import hashlib
+import hmac
+import os
 
 from ..database import teachers_collection
 
@@ -13,20 +15,46 @@ router = APIRouter(
     tags=["auth"]
 )
 
+PBKDF2_ITERATIONS = 310000
+SALT_SIZE = 16
+
 def hash_password(password):
-    """Hash password using SHA-256"""
-    return hashlib.sha256(password.encode()).hexdigest()
+    """Hash password using PBKDF2-HMAC-SHA256 with a per-password salt."""
+    salt = os.urandom(SALT_SIZE)
+    derived_key = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        PBKDF2_ITERATIONS
+    )
+    return f"pbkdf2_sha256${PBKDF2_ITERATIONS}${salt.hex()}${derived_key.hex()}"
+
+def verify_password(password: str, stored_password_hash: str) -> bool:
+    """Verify password against stored hash (PBKDF2 format, with legacy SHA-256 fallback)."""
+    if stored_password_hash.startswith("pbkdf2_sha256$"):
+        try:
+            _, iterations, salt_hex, expected_hex = stored_password_hash.split("$", 3)
+            derived_key = hashlib.pbkdf2_hmac(
+                "sha256",
+                password.encode("utf-8"),
+                bytes.fromhex(salt_hex),
+                int(iterations)
+            )
+            return hmac.compare_digest(derived_key.hex(), expected_hex)
+        except (ValueError, TypeError):
+            return False
+
+    # Backward compatibility for legacy unsalted SHA-256 hashes already stored.
+    legacy_hash = hashlib.sha256(password.encode("utf-8")).hexdigest()
+    return hmac.compare_digest(legacy_hash, stored_password_hash)
 
 @router.post("/login")
 def login(username: str, password: str) -> Dict[str, Any]:
     """Login a teacher account"""
-    # Hash the provided password
-    hashed_password = hash_password(password)
-    
     # Find the teacher in the database
     teacher = teachers_collection.find_one({"_id": username})
     
-    if not teacher or teacher["password"] != hashed_password:
+    if not teacher or not verify_password(password, teacher["password"]):
         raise HTTPException(status_code=401, detail="Invalid username or password")
     
     # Return teacher information (excluding password)


### PR DESCRIPTION
Potential fix for [https://github.com/masa-fleet/skills-expand-your-team-with-copilot/security/code-scanning/1](https://github.com/masa-fleet/skills-expand-your-team-with-copilot/security/code-scanning/1)

Use a dedicated password hashing function instead of SHA-256, while preserving current behavior as much as possible.  
The best single-file fix here is to replace `hash_password` with PBKDF2-HMAC-SHA256 via `hashlib.pbkdf2_hmac`, with a per-password random salt and stored format `pbkdf2_sha256$iterations$salt_hex$hash_hex`. Then, in `login`, verify entered password against stored hash using constant-time comparison (`hmac.compare_digest`), and include a backward-compatible fallback for existing legacy SHA-256 hashes so existing users can still log in without immediate DB migration.

In `src/backend/routers/auth.py`:
- Add imports: `hmac`, `os`.
- Replace the current `hash_password` implementation with:
  - `hash_password(password)` returning PBKDF2 formatted string.
  - `verify_password(password, stored_password_hash)` supporting PBKDF2 format and fallback to legacy SHA-256.
- Update login check from direct equality (`teacher["password"] != hashed_password`) to `not verify_password(...)`.

This addresses both alert variants at the same sink and removes insecure password hashing usage for active authentication verification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
